### PR TITLE
@Decrypt增加时间戳校验和是否加密校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ### 1.介绍
 **rsa-encrypt-body-spring-boot**  
-Spring Boot接口加密，可以对返回值、参数值通过注解的方式自动加解密
-。  
+Spring Boot接口加密，可以对返回值、参数值通过注解的方式自动加解密。  
 
  [![](https://img.shields.io/badge/Author-Bobby-ff69b4.svg)]()
 ### 2.使用方法
@@ -10,7 +9,7 @@ Spring Boot接口加密，可以对返回值、参数值通过注解的方式自
 <dependency>
   <groupId>cn.shuibo</groupId>
   <artifactId>rsa-encrypt-body-spring-boot</artifactId>
-  <version>1.0.1.RELEASE</version>
+  <version>1.0.2.RELEASE</version>
 </dependency>
 ```
 **Gradle Groovy DSL**
@@ -23,7 +22,7 @@ implementation 'cn.shuibo:rsa-encrypt-body-spring-boot:1.0.1.RELEASE'
 <dependency>
     <groupId>cn.shuibo</groupId>
     <artifactId>rsa-encrypt-body-spring-boot</artifactId>
-    <version>1.0.1.RELEASE</version>
+    <version>1.0.2.RELEASE</version>
 </dependency>
 ```
 - **启动类Application中添加@EnableSecurity注解**
@@ -44,6 +43,7 @@ rsa:
   encrypt:
     open: true # 是否开启加密 true  or  false
     showLog: true # 是否打印加解密log true  or  false
+    timestampCheck: true # 是否开启时间戳检查 ture or false
     publicKey: # RSA公钥
     privateKey: # RSA私钥
 ```
@@ -68,6 +68,26 @@ public String Decryption(@RequestBody TestBean testBean){
     return testBean.toString();
 }
 ```
+
+- **@Decrypt**
+```java
+public @interface Decrypt{
+
+    /**
+     * 请求参数一定要是加密内容
+     */
+    boolean required() default false;
+
+    /**
+     * 请求数据时间戳校验时间差
+     * 超过(当前时间-指定时间)的数据认定为伪造
+     * 注意应用程序需要捕获 {@link cn.shuibo.exception.EncryptRequestException} 异常
+     */
+    long timeout() default 3000;
+}
+
+```
+
 ### 3.About author
 ![](https://ss3.baidu.com/9fo3dSag_xI4khGko9WTAnF6hhy/super/pic/item/5366d0160924ab18a5f64be03bfae6cd7a890b00.jpg)
 - Blog：https://shuibo.cn

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>cn.shuibo</groupId>
     <artifactId>rsa-encrypt-body-spring-boot</artifactId>
-    <version>1.0.1.RELEASE</version>
+    <version>1.0.2.RELEASE</version>
     <name>rsa-encrypt-body-spring-boot</name>
     <description>Spring Boot 接口请求参数自动加解密</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>1.2.56</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>

--- a/src/main/java/cn/shuibo/advice/DecryptHttpInputMessage.java
+++ b/src/main/java/cn/shuibo/advice/DecryptHttpInputMessage.java
@@ -4,8 +4,8 @@ import cn.shuibo.annotation.Decrypt;
 import cn.shuibo.config.SecretKeyConfig;
 import cn.shuibo.exception.EncryptRequestException;
 import cn.shuibo.util.Base64Util;
+import cn.shuibo.util.JsonUtils;
 import cn.shuibo.util.RSAUtil;
-import com.alibaba.fastjson.JSON;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class DecryptHttpInputMessage implements HttpInputMessage {
         if (timestampCheck) {
             // 容忍最小请求时间
             long toleranceTime = System.currentTimeMillis() - decrypt.timeout();
-            long requestTime = JSON.parseObject(decryptBody).getLongValue("timestamp");
+            long requestTime = JsonUtils.getNode(decryptBody, "timestamp").asLong();
             // 如果请求时间小于最小容忍请求时间, 判定为超时
             if (requestTime < toleranceTime) {
                 log.error("Encryption request has timed out, toleranceTime:{}, requestTime:{}, After decryption：{}", toleranceTime, requestTime, decryptBody);

--- a/src/main/java/cn/shuibo/advice/DecryptHttpInputMessage.java
+++ b/src/main/java/cn/shuibo/advice/DecryptHttpInputMessage.java
@@ -1,10 +1,16 @@
 package cn.shuibo.advice;
 
+import cn.shuibo.annotation.Decrypt;
+import cn.shuibo.config.SecretKeyConfig;
+import cn.shuibo.exception.EncryptRequestException;
 import cn.shuibo.util.Base64Util;
 import cn.shuibo.util.RSAUtil;
+import com.alibaba.fastjson.JSON;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -12,22 +18,23 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpInputMessage;
-
 /**
  * Author:Bobby
  * DateTime:2019/4/9
  **/
-public class DecryptHttpInputMessage implements HttpInputMessage{
+public class DecryptHttpInputMessage implements HttpInputMessage {
 
     private Logger log = LoggerFactory.getLogger(this.getClass());
     private HttpHeaders headers;
     private InputStream body;
 
 
-    public DecryptHttpInputMessage(HttpInputMessage inputMessage, String privateKey, String charset, boolean showLog) throws Exception {
+    public DecryptHttpInputMessage(HttpInputMessage inputMessage, SecretKeyConfig secretKeyConfig, Decrypt decrypt) throws Exception {
+
+        String privateKey =  secretKeyConfig.getPrivateKey();
+        String charset = secretKeyConfig.getCharset();
+        boolean showLog = secretKeyConfig.isShowLog();
+        boolean timestampCheck = secretKeyConfig.isTimestampCheck();
 
         if (StringUtils.isEmpty(privateKey)) {
             throw new IllegalArgumentException("privateKey is null");
@@ -37,7 +44,13 @@ public class DecryptHttpInputMessage implements HttpInputMessage{
         String content = new BufferedReader(new InputStreamReader(inputMessage.getBody()))
                 .lines().collect(Collectors.joining(System.lineSeparator()));
         String decryptBody;
+        // 未加密内容
         if (content.startsWith("{")) {
+            // 必须加密
+            if (decrypt.required()) {
+                log.error("not support unencrypted content:{}", content);
+                throw new EncryptRequestException("not support unencrypted content");
+            }
             log.info("Unencrypted without decryption:{}", content);
             decryptBody = content;
         } else {
@@ -56,6 +69,19 @@ public class DecryptHttpInputMessage implements HttpInputMessage{
                 log.info("Encrypted data received：{},After decryption：{}", content, decryptBody);
             }
         }
+
+        // 开启时间戳检查
+        if (timestampCheck) {
+            // 容忍最小请求时间
+            long toleranceTime = System.currentTimeMillis() - decrypt.timeout();
+            long requestTime = JSON.parseObject(decryptBody).getLongValue("timestamp");
+            // 如果请求时间小于最小容忍请求时间, 判定为超时
+            if (requestTime < toleranceTime) {
+                log.error("Encryption request has timed out, toleranceTime:{}, requestTime:{}, After decryption：{}", toleranceTime, requestTime, decryptBody);
+                throw new EncryptRequestException("request timeout");
+            }
+        }
+
         this.body = new ByteArrayInputStream(decryptBody.getBytes());
     }
 

--- a/src/main/java/cn/shuibo/advice/EncryptRequestBodyAdvice.java
+++ b/src/main/java/cn/shuibo/advice/EncryptRequestBodyAdvice.java
@@ -35,13 +35,17 @@ public class EncryptRequestBodyAdvice  implements RequestBodyAdvice {
     public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
         Method method = methodParameter.getMethod();
         if (Objects.isNull(method)) {
-            return encrypt;
+            encrypt = false;
+            return false;
         }
         if (method.isAnnotationPresent(Decrypt.class) && secretKeyConfig.isOpen()) {
             encrypt = true;
             decryptAnnotation = methodParameter.getMethodAnnotation(Decrypt.class);
+            return true;
         }
-        return encrypt;
+        // 此处如果按照原逻辑直接返回encrypt, 会造成一次修改为true之后, 后续请求都会变成true, 在不支持时, 需要做修正
+        encrypt = false;
+        return false;
     }
 
     @Override

--- a/src/main/java/cn/shuibo/advice/EncryptResponseBodyAdvice.java
+++ b/src/main/java/cn/shuibo/advice/EncryptResponseBodyAdvice.java
@@ -3,8 +3,8 @@ package cn.shuibo.advice;
 import cn.shuibo.annotation.Encrypt;
 import cn.shuibo.config.SecretKeyConfig;
 import cn.shuibo.util.Base64Util;
+import cn.shuibo.util.JsonUtils;
 import cn.shuibo.util.RSAUtil;
-import com.alibaba.fastjson.JSON;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +59,7 @@ public class EncryptResponseBodyAdvice implements ResponseBodyAdvice<Object> {
         if (encrypt) {
             String publicKey = secretKeyConfig.getPublicKey();
             try {
-                String content = JSON.toJSONString(body);
+                String content = JsonUtils.writeValueAsString(body);
                 if (!StringUtils.hasText(publicKey)) {
                     throw new NullPointerException("Please configure rsa.encrypt.privatekeyc parameter!");
                 }
@@ -74,6 +74,7 @@ public class EncryptResponseBodyAdvice implements ResponseBodyAdvice<Object> {
                 log.error("Encrypted data exception", e);
             }
         }
+
         return body;
     }
 }

--- a/src/main/java/cn/shuibo/advice/EncryptResponseBodyAdvice.java
+++ b/src/main/java/cn/shuibo/advice/EncryptResponseBodyAdvice.java
@@ -17,6 +17,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
+import java.lang.reflect.Method;
+import java.util.Objects;
+
 /**
  * Author:Bobby
  * DateTime:2019/4/9
@@ -35,10 +38,11 @@ public class EncryptResponseBodyAdvice implements ResponseBodyAdvice<Object> {
 
     @Override
     public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
-        encrypt = false;
-        if (returnType.getMethod().isAnnotationPresent(Encrypt.class) && secretKeyConfig.isOpen()) {
-            encrypt = true;
+        Method method = returnType.getMethod();
+        if (Objects.isNull(method)) {
+            return encrypt;
         }
+        encrypt = method.isAnnotationPresent(Encrypt.class) && secretKeyConfig.isOpen();
         return encrypt;
     }
 

--- a/src/main/java/cn/shuibo/annotation/Decrypt.java
+++ b/src/main/java/cn/shuibo/annotation/Decrypt.java
@@ -1,5 +1,7 @@
 package cn.shuibo.annotation;
 
+import cn.shuibo.exception.EncryptRequestException;
+
 import java.lang.annotation.*;
 
 /**
@@ -11,4 +13,15 @@ import java.lang.annotation.*;
 @Documented
 public @interface Decrypt{
 
+    /**
+     * 请求参数一定要是加密内容
+     */
+    boolean required() default false;
+
+    /**
+     * 请求数据时间戳校验时间差
+     * 超过(当前时间-指定时间)的数据认定为伪造
+     * 注意应用程序需要捕获 {@link EncryptRequestException} 异常
+     */
+    long timeout() default 3000;
 }

--- a/src/main/java/cn/shuibo/config/SecretKeyConfig.java
+++ b/src/main/java/cn/shuibo/config/SecretKeyConfig.java
@@ -21,6 +21,12 @@ public class SecretKeyConfig{
 
     private boolean showLog = false;
 
+    /**
+     * 请求数据时间戳校验时间差
+     * 超过指定时间的数据认定为伪造
+     */
+    private boolean timestampCheck = false;
+
     public String getPrivateKey() {
         return privateKey;
     }
@@ -59,5 +65,13 @@ public class SecretKeyConfig{
 
     public void setShowLog(boolean showLog) {
         this.showLog = showLog;
+    }
+
+    public boolean isTimestampCheck() {
+        return timestampCheck;
+    }
+
+    public void setTimestampCheck(boolean timestampCheck) {
+        this.timestampCheck = timestampCheck;
     }
 }

--- a/src/main/java/cn/shuibo/exception/EncryptRequestException.java
+++ b/src/main/java/cn/shuibo/exception/EncryptRequestException.java
@@ -1,0 +1,14 @@
+package cn.shuibo.exception;
+
+
+/**
+ * @author imyzt
+ * @date 2020/06/02
+ * @description 加密请求超时异常
+ */
+public class EncryptRequestException extends RuntimeException {
+
+    public EncryptRequestException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/cn/shuibo/util/JsonUtils.java
+++ b/src/main/java/cn/shuibo/util/JsonUtils.java
@@ -1,0 +1,30 @@
+package cn.shuibo.util;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * @author imyzt
+ * @date 2020/06/08
+ * @description JSON 工具类
+ */
+public class JsonUtils {
+
+    private JsonUtils() {
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static JsonNode getNode(String content, String key) throws IOException {
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(content);
+        return jsonNode.get(key);
+    }
+
+    public static String writeValueAsString(Object body) throws JsonProcessingException {
+        return OBJECT_MAPPER.writeValueAsString(body);
+    }
+}


### PR DESCRIPTION
@Decrypt可以对请求包中时间戳进行校验，可选择是否开启

```
public @interface Decrypt{

    /**
     * 请求参数一定要是加密内容
     */
    boolean required() default false;

    /**
     * 请求数据时间戳校验时间差
     * 超过(当前时间-指定时间)的数据认定为伪造
     * 注意应用程序需要捕获 {@link EncryptRequestException} 异常
     */
    long timeout() default 3000;
}
```
